### PR TITLE
Add DevSuite directory tree module

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,37 @@ DevSuite::SomeUtility.do_something
   ```
 </details>
 
+<details>
+  <summary><strong>Directory Tree Visualization</strong></summary>
+  
+  Visualize the structure of directories and their subdirectories with a detailed hierarchical representation. This tool is essential for understanding the organization of your files and directories at a glance.
+
+  **Usage:**
+  ```ruby
+  require 'dev_suite'
+
+  # Set the base path for the directory you want to visualize
+  base_path = "/path/to/your/directory"
+
+  # Perform the visualization
+  DevSuite::DirectoryTree::Visualizer.visualize(base_path)
+  ```
+
+  **Example output**
+  ```
+  /path/to/your/directory/
+  ├── project/
+  │   ├── src/
+  │   │   ├── main.rb
+  │   │   └── helper.rb
+  │   └── spec/
+  │       └── main_spec.rb
+  ├── doc/
+  │   └── README.md
+  └── test/
+      └── test_helper.rb
+  ```
+</details>
 
 ## Development
 

--- a/lib/dev_suite.rb
+++ b/lib/dev_suite.rb
@@ -2,6 +2,7 @@
 
 require "dev_suite/version"
 require "dev_suite/performance"
+require "dev_suite/directory_tree"
 
 module DevSuite
   class Error < StandardError; end

--- a/lib/dev_suite/directory_tree.rb
+++ b/lib/dev_suite/directory_tree.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module DevSuite
+  module DirectoryTree
+    require_relative "directory_tree/visualizer"
+  end
+end

--- a/lib/dev_suite/directory_tree/node.rb
+++ b/lib/dev_suite/directory_tree/node.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DevSuite
+  module DirectoryTree
+    module Node
+      require_relative "node/file"
+      require_relative "node/directory"
+      require_relative "node/permission_denied"
+    end
+  end
+end

--- a/lib/dev_suite/directory_tree/node/base.rb
+++ b/lib/dev_suite/directory_tree/node/base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module DevSuite
+  module DirectoryTree
+    module Node
+      class Base
+        attr_reader :name
+
+        def initialize(name)
+          @name = name
+        end
+
+        def directory?
+          raise NotImplementedError, "Must implement in subclass"
+        end
+      end
+    end
+  end
+end

--- a/lib/dev_suite/directory_tree/node/directory.rb
+++ b/lib/dev_suite/directory_tree/node/directory.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module DevSuite
+  module DirectoryTree
+    module Node
+      class Directory < Base
+        attr_reader :children
+
+        def initialize(name)
+          super
+          @children = []
+        end
+
+        def directory?
+          true
+        end
+
+        def add_child(child)
+          @children << child
+        end
+      end
+    end
+  end
+end

--- a/lib/dev_suite/directory_tree/node/file.rb
+++ b/lib/dev_suite/directory_tree/node/file.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module DevSuite
+  module DirectoryTree
+    module Node
+      class File < Base
+        def directory?
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/dev_suite/directory_tree/node/permission_denied.rb
+++ b/lib/dev_suite/directory_tree/node/permission_denied.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module DevSuite
+  module DirectoryTree
+    module Node
+      class PermissionDenied < Base
+        # This class is used to represent a file or directory that the user does not have permission to access.
+        def initialize(name, is_directory)
+          super(name)
+          @is_directory = is_directory
+        end
+
+        def directory?
+          @is_directory
+        end
+
+        def children
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/dev_suite/directory_tree/renderer.rb
+++ b/lib/dev_suite/directory_tree/renderer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DevSuite
+  module DirectoryTree
+    module Renderer
+      require_relative "renderer/simple"
+    end
+  end
+end

--- a/lib/dev_suite/directory_tree/renderer/base.rb
+++ b/lib/dev_suite/directory_tree/renderer/base.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+module DevSuite
+  module DirectoryTree
+    module Renderer
+      class Base
+        def initialize(base_path)
+          @base_path = Pathname.new(base_path)
+        end
+
+        def render
+          root = build_tree(@base_path)
+          render_node(root, "", true)
+        end
+
+        private
+
+        # Builds the tree structure
+        # @param path [Pathname] The path to build the tree from
+        # @return [Node::Base] The root node of the tree
+        def build_tree(path)
+          raise NotImplementedError, "You must implement the build_tree method"
+        end
+
+        # Renders a node in the tree
+        # @param node [Node::Base] The node to render
+        # @param prefix [String] The prefix to add to the node
+        # @param is_last [Boolean] Whether this is the last node in the list
+        # @return [String] The rendered node
+        def render_node(node, prefix, is_last)
+          raise NotImplementedError, "You must implement the render_node method"
+        end
+      end
+    end
+  end
+end

--- a/lib/dev_suite/directory_tree/renderer/simple.rb
+++ b/lib/dev_suite/directory_tree/renderer/simple.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "base"
+require_relative "../node"
+
+module DevSuite
+  module DirectoryTree
+    module Renderer
+      class Simple < Base
+        private
+
+        def build_tree(path)
+          return Node::PermissionDenied.new(path.basename.to_s, path.directory?) unless path.readable?
+
+          if path.directory?
+            dir = Node::Directory.new(path.basename.to_s)
+            children = path.children.sort_by { |child| child.basename.to_s.downcase }
+            children.each do |child|
+              dir.add_child(build_tree(child))
+            end
+            dir
+          else
+            Node::File.new(path.basename.to_s)
+          end
+        rescue Errno::EACCES
+          Node::PermissionDenied.new(path.basename.to_s, path.directory?)
+        end
+
+        def render_node(node, prefix = "", is_last = true)
+          # Determine if this is the root node based on the prefix content
+          is_root = prefix.empty?
+
+          # Prepare the connector appropriately, omitting it for the root
+          connector = if is_root
+            ""
+          else
+            (is_last ? "└── " : "├── ")
+          end
+
+          # Compute the new prefix for children
+          new_prefix = "#{prefix}#{is_last ? "    " : "|   "}"
+
+          # Construct the output for the current node, avoiding the connector for the root
+          output = "#{prefix}#{connector}#{node.name}"
+          output += "/\n" if node.directory?
+
+          # Recursively render children if it's a directory
+          if node.directory? && node.children.any?
+            node.children.each_with_index do |child, index|
+              output += render_node(child, new_prefix, index == node.children.size - 1)
+            end
+          elsif !node.directory?
+            output += "\n"
+          end
+
+          output
+        end
+      end
+    end
+  end
+end

--- a/lib/dev_suite/directory_tree/visualizer.rb
+++ b/lib/dev_suite/directory_tree/visualizer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "pathname"
+require_relative "renderer"
+
+module DevSuite
+  module DirectoryTree
+    class Visualizer
+      class << self
+        # Visualizes the directory tree
+        # @param base_path [String] The base path of the directory
+        def visualize(base_path)
+          new(base_path).visualize
+        end
+      end
+
+      def initialize(base_path, renderer: Renderer::Simple.new(base_path))
+        @renderer = renderer
+      end
+
+      def visualize
+        puts @renderer.render
+      end
+    end
+  end
+end

--- a/lib/dev_suite/performance/reportor/base.rb
+++ b/lib/dev_suite/performance/reportor/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DevSuite
   module Performance
     module Reportor

--- a/spec/dev_suite/directory_tree/visualizer_spec.rb
+++ b/spec/dev_suite/directory_tree/visualizer_spec.rb
@@ -1,0 +1,112 @@
+# spec/dev_suite/directory_tree/visualizer_spec.rb
+require 'rspec'
+require 'pathname'
+
+RSpec.describe DevSuite::DirectoryTree::Visualizer do
+  let(:base_path) { Pathname.new(Dir.mktmpdir) }
+
+  before do
+    #
+    # Create a sample directory structure
+    #
+    (base_path + 'dir1').mkdir
+    (base_path + 'dir1/file1.txt').write('content1')
+    (base_path + 'dir2').mkdir
+    (base_path + 'dir2/file2.txt').write('content2')
+  end
+
+  after do
+    FileUtils.remove_entry base_path
+  end
+
+  describe '.visualize' do
+    subject { described_class }
+
+    it 'creates a new instance and calls visualize on it' do
+      visualizer_instance = instance_double(subject)
+      allow(subject).to receive(:new).with(base_path.to_s).and_return(visualizer_instance)
+      expect(visualizer_instance).to receive(:visualize)
+      subject.visualize(base_path.to_s)
+    end
+
+    it 'outputs the correct directory structure' do
+      expected_output = <<~OUTPUT
+        #{base_path.basename}/
+            ├── dir1/
+            |   └── file1.txt
+            └── dir2/
+                └── file2.txt
+      OUTPUT
+
+      expect { subject.visualize(base_path.to_s) }.to output(expected_output).to_stdout
+    end
+
+    it 'handles nested directories correctly' do
+      (base_path + 'dir1/subdir1').mkdir
+      (base_path + 'dir1/subdir1/file3.txt').write('content3')
+
+      expected_output = <<~OUTPUT
+        #{base_path.basename}/
+            ├── dir1/
+            |   ├── file1.txt
+            |   └── subdir1/
+            |       └── file3.txt
+            └── dir2/
+                └── file2.txt
+      OUTPUT
+
+      expect { subject.visualize(base_path.to_s) }.to output(expected_output).to_stdout
+    end
+
+    it 'handles empty directories correctly' do
+      (base_path + 'empty_dir').mkdir
+
+      expected_output = <<~OUTPUT
+        #{base_path.basename}/
+            ├── dir1/
+            |   └── file1.txt
+            ├── dir2/
+            |   └── file2.txt
+            └── empty_dir/
+      OUTPUT
+
+      expect { subject.visualize(base_path.to_s) }.to output(expected_output).to_stdout
+    end
+
+    it 'handles directories with only files correctly' do
+      (base_path + 'file_only_dir').mkdir
+      (base_path + 'file_only_dir/file3.txt').write('content3')
+
+      expected_output = <<~OUTPUT
+        #{base_path.basename}/
+            ├── dir1/
+            |   └── file1.txt
+            ├── dir2/
+            |   └── file2.txt
+            └── file_only_dir/
+                └── file3.txt
+      OUTPUT
+
+      expect { subject.visualize(base_path.to_s) }.to output(expected_output).to_stdout
+    end
+
+    it 'handles directories with no read permissions gracefully' do
+      (base_path + 'no_read_dir').mkdir
+      (base_path + 'no_read_dir').chmod(0000)
+
+      expected_output = <<~OUTPUT
+        #{base_path.basename}/
+            ├── dir1/
+            |   └── file1.txt
+            ├── dir2/
+            |   └── file2.txt
+            └── no_read_dir/
+      OUTPUT
+
+      expect { subject.visualize(base_path.to_s) }.to output(expected_output).to_stdout
+
+      # Restore permissions for cleanup
+      (base_path + 'no_read_dir').chmod(0755)
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [x] Adds a new directory tree module to the DevSuite library. 
- [x] The module includes submodules for visualizing the directory tree and rendering the tree structure. 
- [x] Introduces new classes for representing nodes in the directory tree, including files, directories, and permission denied nodes.
- [x] Update README
- [ ] Update version to v0.1.2