### PR TITLE
[Refactor] configuration attributes in `ConfigTools::Configuration` modules

### DIFF
--- a/lib/dev_suite/directory_tree/config.rb
+++ b/lib/dev_suite/directory_tree/config.rb
@@ -6,30 +6,25 @@ module DevSuite
       include Utils::ConfigTools::Configuration
 
       # Define configuration attributes
-      config_attr :settings, :builder, :renderer, :visualizer
-
-      def initialize(settings: {}, builder: :base, renderer: :simple, visualizer: :tree)
-        # Set default values for settings, renderer and builder.
-        self.settings = settings
-        self.builder = builder
-        self.renderer = renderer
-        self.visualizer = visualizer
-      end
+      config_attr :settings, default_value: {}
+      config_attr :builder, default_value: :base
+      config_attr :renderer, default_value: :simple
+      config_attr :visualizer, default_value: :tree
 
       private
 
-      def validate_config_attr(attr, value)
+      def validate_attr!(attr, value)
         case attr
-        when :builder, :renderer, :visualizer
-          raise ArgumentError, "Invalid #{attr} value" unless value.is_a?(Symbol)
         when :settings
-          raise ArgumentError, "Settings must be a hash" unless value.is_a?(Hash)
+          validate_hash!(attr, value)
+        when :builder, :renderer, :visualizer
+          validate_symbol!(attr, value)
         else
-          raise ArgumentError, "Invalid attribute"
+          raise ArgumentError, "Invalid attribute: #{attr}"
         end
       end
 
-      def resolve_config_attr(attr, value)
+      def resolve_attr(attr, value)
         case attr
         when :settings
           Settings.new(value)
@@ -40,7 +35,7 @@ module DevSuite
         when :visualizer
           Visualizer.create(value)
         else
-          raise ArgumentError, "Invalid attribute"
+          super # Return the value directly if no special resolution is needed
         end
       end
     end

--- a/lib/dev_suite/performance/config.rb
+++ b/lib/dev_suite/performance/config.rb
@@ -6,26 +6,23 @@ module DevSuite
       include Utils::ConfigTools::Configuration
 
       # Define configuration attributes
-      config_attr :profilers, :reportor
-
-      def initialize(profilers: [:execution_time, :memory], reportor: :simple)
-        # Set default values for profilers and reportor.
-        self.profilers = profilers
-        self.reportor = reportor
-      end
+      config_attr :profilers, default_value: [:execution_time, :memory]
+      config_attr :reportor, default_value: :simple
 
       private
 
-      def validate_config_attr(attr, value)
+      def validate_attr!(attr, value)
         case attr
         when :profilers
-          validate_profilers(value)
+          validate_array!(attr, value)
         when :reportor
-          validate_reportor(value)
+          validate_symbol!(attr, value)
+        else
+          raise ArgumentError, "Invalid attribute: #{attr}"
         end
       end
 
-      def resolve_config_attr(attr, value)
+      def resolve_attr(attr, value)
         case attr
         when :profilers
           Profiler.create_multiple(value)
@@ -33,18 +30,6 @@ module DevSuite
           Reportor.create(value)
         else
           value
-        end
-      end
-
-      def validate_profilers(value)
-        unless value.is_a?(Array) && value.all? { |v| v.is_a?(Symbol) }
-          raise ArgumentError, "Profilers must be an array of symbols"
-        end
-      end
-
-      def validate_reportor(value)
-        unless value.is_a?(Symbol)
-          raise ArgumentError, "Invalid reportor value"
         end
       end
     end

--- a/lib/dev_suite/utils/config_tools/configuration.rb
+++ b/lib/dev_suite/utils/config_tools/configuration.rb
@@ -13,52 +13,114 @@ module DevSuite
         end
 
         module ClassMethods
-          #
-          # Provide global access to a single instance of Config
-          #
+          # Provides global access to a single instance of the configuration class
+          # @return [Object] The singleton configuration instance
           def configuration
             @configuration ||= new
           end
 
-          #
-          # Allow block-based configuration
-          #
+          # Allows block-based configuration
+          # Example usage:
+          #   ConfigClass.configure do |config|
+          #     config.attr_name = value
+          #   end
           def configure
             yield(configuration)
           rescue StandardError => e
             ErrorHandler.handle_error(e)
           end
 
-          def config_attr(*attrs)
-            attrs.each do |attr|
-              define_method(attr) do
-                instance_variable_get("@#{attr}") || instance_variable_get("@#{attr}_resolved")
-              end
+          # Defines a configuration attribute with an optional default value
+          # This method automatically creates getter and setter methods for the attribute
+          #
+          # @param attr_name [Symbol] The name of the attribute
+          # @param default_value [Object] The default value for the attribute
+          def config_attr(attr_name, default_value: nil)
+            config_attrs[attr_name] = default_value
 
-              define_method("#{attr}=") do |value|
-                validate_config_attr(attr, value)
-                instance_variable_set("@#{attr}", resolve_config_attr(attr, value))
-              end
+            # Getter method for the attribute
+            define_method(attr_name) do
+              instance_variable_get("@#{attr_name}")
             end
+
+            # Setter method for the attribute with validation and resolution
+            define_method("#{attr_name}=") do |value|
+              validate_attr!(attr_name, value)
+              instance_variable_set("@#{attr_name}", resolve_attr(attr_name, value))
+            end
+          end
+
+          # Stores configuration attributes and their default values
+          # @return [Hash] A hash of attribute names and their default values
+          def config_attrs
+            @config_attrs ||= {}
           end
         end
 
+        # Module for instance-level methods
         module InstanceMethods
           private
 
-          def validate_config_attr!(attr, value)
+          # Initializes configuration attributes with provided or default values
+          # This method is called automatically during object initialization
+          #
+          # @param options [Hash] A hash of attribute names and their values
+          def initialize(**options)
+            initialize_attributes(options)
+          end
+
+          # Sets up each attribute with either the provided value or the default value
+          #
+          # @param options [Hash] A hash of attribute names and their values
+          def initialize_attributes(options)
+            self.class.config_attrs.each do |attr_name, default_value|
+              value = options.fetch(attr_name, default_value)
+              send("#{attr_name}=", value)
+            end
+          end
+
+          # Validates an attribute's value based on its type
+          # Override this method in the including class to add custom validation logic
+          #
+          # @param attr [Symbol] The name of the attribute
+          # @param value [Object] The value to validate
+          def validate_attr!(attr, value)
             # Override in including class for custom validation logic
           end
 
-          def resolve_config_attr(attr, value)
-            # Override in including class to resolve symbols to objects
-            value
+          # Validates that an attribute's value is a Hash
+          #
+          # @param attr [Symbol] The name of the attribute
+          # @param value [Object] The value to validate
+          def validate_hash!(attr, value)
+            raise ArgumentError, "Invalid #{attr} value: expected a Hash" unless value.is_a?(Hash)
           end
 
-          def initialize(**options)
-            options.each do |key, value|
-              send("#{key}=", value) if respond_to?("#{key}=")
-            end
+          # Validates that an attribute's value is a Symbol
+          #
+          # @param attr [Symbol] The name of the attribute
+          # @param value [Object] The value to validate
+          def validate_symbol!(attr, value)
+            raise ArgumentError, "Invalid #{attr} value: expected a Symbol" unless value.is_a?(Symbol)
+          end
+
+          # Validates that an attribute's value is an Array
+          #
+          # @param attr [Symbol] The name of the attribute
+          # @param value [Object] The value to validate
+          def validate_array!(attr, value)
+            raise ArgumentError, "Invalid #{attr} value: expected an Array" unless value.is_a?(Array)
+          end
+
+          # Resolves the value of an attribute, especially if it requires
+          # converting a symbol to an object. Override in the including class.
+          #
+          # @param _attr [Symbol] The name of the attribute
+          # @param value [Object] The value to resolve
+          # @return [Object] The resolved value
+          def resolve_attr(_attr, value)
+            # Override in including class to resolve symbols to objects
+            value
           end
         end
       end

--- a/lib/dev_suite/utils/config_tools/configuration.rb
+++ b/lib/dev_suite/utils/config_tools/configuration.rb
@@ -85,7 +85,10 @@ module DevSuite
           # @param attr [Symbol] The name of the attribute
           # @param value [Object] The value to validate
           def validate_attr!(attr, value)
-            # Override in including class for custom validation logic
+            raise ArgumentError, "Unknown attribute: #{attr}" unless self.class.config_attrs.key?(attr)
+            raise ArgumentError, "Invalid #{attr} value: #{value}" if value.nil?
+
+            # Override in including class to add custom validation logic
           end
 
           # Validates that an attribute's value is a Hash
@@ -118,7 +121,9 @@ module DevSuite
           # @param _attr [Symbol] The name of the attribute
           # @param value [Object] The value to resolve
           # @return [Object] The resolved value
-          def resolve_attr(_attr, value)
+          def resolve_attr(attr, value)
+            raise ArgumentError, "Unknown attribute: #{attr}" unless self.class.config_attrs.key?(attr)
+
             # Override in including class to resolve symbols to objects
             value
           end


### PR DESCRIPTION
- Update `config.rb` files in `dev_suite/performance` and `dev_suite/directory_tree` modules
- Use `config_attr` method to define configuration attributes with default values
- Remove unnecessary validation methods and simplify attribute validation
- Update attribute resolution methods to use case statements for better readability