### PR TITLE
[Refactor] Improve deep_merge method and delete_key_from_structure

### DIFF
--- a/lib/dev_suite/utils/data/base_operations.rb
+++ b/lib/dev_suite/utils/data/base_operations.rb
@@ -7,62 +7,50 @@ module DevSuite
         # Recursively delete a key from any level in the data structure
         def deep_delete_key(data, key_to_delete)
           case data
-          when Hash
-            delete_key_from_hash(data, key_to_delete)
-          when Array
-            delete_key_from_array(data, key_to_delete)
+          when Hash, Array
+            delete_key_from_structure(data, key_to_delete)
           else
             data
           end
         end
 
-        # Non-destructive deep merge
-        def deep_merge(hash1, hash2)
-          hash1 = hash1.dup # Ensure we don't modify the original hash1
-          deep_merge!(hash1, hash2)
-        end
-
         # Destructive deep merge (modifies hash1)
         def deep_merge!(hash1, hash2)
-          return hash1 if hash2.nil? # If hash2 is nil, return hash1 as-is
+          return hash1 if hash2.nil?
 
           hash2.each do |key, new_val|
-            if hash1[key].is_a?(Hash) && new_val.is_a?(Hash)
-              # Recursively merge nested hashes
-              deep_merge!(hash1[key], new_val)
-            else
-              # Overwrite or add the value from hash2
-              hash1[key] = new_val
-            end
+            hash1[key] = merge_value(hash1[key], new_val)
           end
           hash1
         end
 
+        # Non-destructive deep merge
+        def deep_merge(hash1, hash2)
+          deep_merge!(hash1.dup, hash2)
+        end
+
         private
 
-        # Helper method to delete a key from a hash recursively
-        def delete_key_from_hash(hash, key_to_delete)
-          hash.each_with_object({}) do |(key, value), result|
-            unless key == key_to_delete
-              result[key] = deep_delete_key(value, key_to_delete)
-            end
+        # Helper to merge individual values based on their types
+        def merge_value(old_val, new_val)
+          if old_val.is_a?(Hash) && new_val.is_a?(Hash)
+            deep_merge!(old_val, new_val)
+          else
+            new_val
           end
         end
 
-        # Helper method to recursively delete keys from array elements
-        def delete_key_from_array(array, key_to_delete)
-          array.map { |item| deep_delete_key(item, key_to_delete) }
-        end
-
-        # Helper: Traverse a nested hash or array
-        def traverse_data(data, &block)
+        # Helper method to delete key from both Hash and Array recursively
+        def delete_key_from_structure(data, key_to_delete)
           case data
           when Hash
             data.each_with_object({}) do |(key, value), result|
-              result[key] = yield(key, traverse_data(value, &block))
+              unless key == key_to_delete
+                result[key] = deep_delete_key(value, key_to_delete)
+              end
             end
           when Array
-            data.map { |item| traverse_data(item, &block) }
+            data.map { |item| deep_delete_key(item, key_to_delete) }
           else
             data
           end


### PR DESCRIPTION
Refactor the deep_merge method in the DevSuite::BaseOperations module to improve its functionality. The method now handles merging nested hashes correctly. Additionally, refactor the delete_key_from_structure method to delete keys from both Hash and Array structures recursively.