### PR TITLE
[Fix] Refactor component manager and store driver construction

### DIFF
--- a/lib/dev_suite/utils/construct/component/manager.rb
+++ b/lib/dev_suite/utils/construct/component/manager.rb
@@ -32,7 +32,12 @@ module DevSuite
 
               raise ArgumentError, "Component not found for key: #{component_key}" unless component_class
 
-              component_class.new(**options, &block)
+              # Check if options are empty to avoid passing unnecessary keyword arguments in Ruby 2.6
+              if options.empty?
+                component_class.new(&block)
+              else
+                component_class.new(**options, &block)
+              end
             end
 
             # Build multiple components by filtering registered ones

--- a/lib/dev_suite/utils/store/store.rb
+++ b/lib/dev_suite/utils/store/store.rb
@@ -44,7 +44,9 @@ module DevSuite
         end
 
         def build_driver(options)
-          Driver.build_component(options.fetch(:driver), **options.except(:driver))
+          driver_type = options.fetch(:driver)
+          driver_options = options.reject { |key, _| key == :driver }
+          Driver.build_component(driver_type, **driver_options)
         end
       end
 


### PR DESCRIPTION
- [x] In the component manager, refactor the construction of components to avoid passing unnecessary keyword arguments in Ruby 2.6. If the options are empty, the component is now instantiated without any arguments. Otherwise, the options are passed as keyword arguments.
- [x] In the store, refactor the construction of the driver by separating the driver type and driver options. The driver type is fetched from the options, and the driver options are obtained by excluding the driver key from the options.